### PR TITLE
feat(data-storage): 타입 추가

### DIFF
--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -6,5 +6,11 @@ module.exports = {
 	transform: {
 		'^.+\\.(t|j)s$': 'ts-jest',
 	},
+	moduleNameMapper: {
+		'^@core/(.*)$': '<rootDir>/core/$1',
+		'^@common/(.*)$': '<rootDir>/common/$1',
+		'^@config/(.*)$': '<rootDir>/config/$1',
+		'^@modules/(.*)$': '<rootDir>/modules/$1',
+	},
 	testTimeout: 60000,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,12 @@ module.exports = {
 	},
 	collectCoverageFrom: ['**/*.(t|j)s'],
 	coveragePathIgnorePatterns: [],
+	moduleNameMapper: {
+		'^@core/(.*)$': '<rootDir>/core/$1',
+		'^@common/(.*)$': '<rootDir>/common/$1',
+		'^@config/(.*)$': '<rootDir>/config/$1',
+		'^@modules/(.*)$': '<rootDir>/modules/$1',
+	},
 	coverageDirectory: '../coverage',
 	testEnvironment: 'node',
 	testTimeout: 60000,

--- a/src/modules/cloud-config/cloud-config.service.ts
+++ b/src/modules/cloud-config/cloud-config.service.ts
@@ -8,7 +8,9 @@ import { CONFIG_DATA_STORAGE_KEY } from './constants';
 export class CloudConfigService {
 	constructor(
 		@Inject(CONFIG_DATA_STORAGE_KEY)
-		private readonly configDataStorage: DataStorage<Record<string, unknown>>,
+		private readonly configDataStorage: DataStorage<{
+			[key: string]: Record<string, unknown>;
+		}>,
 		private readonly cipherService: CipherService,
 	) {}
 

--- a/src/modules/data-storage/impl/yml-file.data-storage.ts
+++ b/src/modules/data-storage/impl/yml-file.data-storage.ts
@@ -35,11 +35,11 @@ export class YmlFileDataStorage implements DataStorage {
 		return parseYml(ymlStr);
 	}
 
-	load(key: string) {
+	async load(key: string) {
 		return this.map.get(key);
 	}
 
-	save(key: string, value: unknown) {
+	async save(key: string, value: unknown) {
 		this.map.set(key, value);
 	}
 }

--- a/src/modules/data-storage/interface.ts
+++ b/src/modules/data-storage/interface.ts
@@ -1,5 +1,16 @@
-export interface DataStorage<T = unknown> {
+export interface DataStorage<T extends KeyValueMapping<any, any> = any> {
 	initialize?(): void | Promise<void>;
-	load(key: string): T | Promise<T> | undefined;
-	save(key: string, value: T): void | Promise<void>;
+	load<K extends KeyType<T>>(key: K): Promise<T[K]> | undefined;
+	save<K extends KeyType<T>>(key: K, value: T[K]): Promise<void>;
 }
+
+type KeyValueMapping<K extends string, V> = {
+	[key in K]: V;
+};
+
+type KeyType<T extends KeyValueMapping<any, any>> = T extends KeyValueMapping<
+	infer K,
+	infer V
+>
+	? K
+	: never;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,12 @@
 		"incremental": true,
 		"skipLibCheck": true,
 		"strict": true,
-		"forceConsistentCasingInFileNames": true
+		"forceConsistentCasingInFileNames": true,
+		"paths": {
+			"@core/*": ["./src/core/*"],
+			"@common/*": ["./src/common/*"],
+			"@config/*": ["./src/config/*"],
+			"@modules/*": ["./src/modules/*"]
+		}
 	}
 }


### PR DESCRIPTION
data storage에 타입을 추가하였습니다

```typescript
const a: DataStorage<{ a: string, b: number }> = {} as any;
const str: string = a.load('a'); // key: a, b 자동완성됨, return type string 자동추론 됨
```